### PR TITLE
add kwargs to job generators

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+from .metarunner import Metarunner
+
+__all__ = ["Metarunner"]

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -8,32 +8,33 @@ print("KERBEROS TICKETS: ", os.system("klist"))
 
 if __name__ == '__main__':
 
-    PROJECT_DIR = "/storage/brno1-cerit/home/sidoj/prompt"
+    #PROJECT_DIR = "/storage/brno1-cerit/home/sidoj/prompt"
+    PROJECT_DIR = "./"
     MAIN_SCRIPT = "src/example.py"
 
     # qsub -I -l walltime=24:0:0 -q gpu@meta-pbs.metacentrum.cz -l select=1:ncpus=1:ngpus=1:mem=40000mb:scratch_local=40000mb:cl_adan=True:mpiprocs=1:ompthreads=1
     # singularity run --nv /cvmfs/singularity.metacentrum.cz/NGC/PyTorch\:21.03-py3.SIF  /storage/brno1-cerit/home/sidoj/phd_augmenter
 
-    def generate_plan_job(job_script):
+    def generate_plan_job(job_script, script_name="augmenter"):
         return f"""#!/bin/bash
                 #PBS -q gpu@cerit-pbs.cerit-sc.cz
                 #P-BS -q gpu@meta-pbs.metacentrum.cz
                 #PBS -l walltime=0:59:0
                 #PBS -l select=1:ncpus=1:ngpus=1:mem=40000mb:scratch_local=40000mb:cl_zia=True
                 #P-BS -l select=1:ncpus=1:ngpus=1:mem=40000mb:scratch_local=40000mb:cl_galdor=True
-                #PBS -N augmenter
+                #PBS -N {script_name}
 
                 /bin/bash {job_script}
                 """
 
 
-    def generate_run_job(named_args):
+    def generate_run_job(named_args, conda_module="prompt"):
         named_params = " ".join(f"--{k} {v}" for k, v in named_args.items())
         return f"""#!/bin/bash
                 module add conda-modules
 
                 HOME=/storage/brno1-cerit/home/sidoj/
-                conda activate prompts
+                conda activate {conda_module}
 
                 export TMPDIR=$SCRATCH
 
@@ -63,10 +64,13 @@ if __name__ == '__main__':
     print(confs)
     input("Press Enter to continue...")
     for config in confs:
-        print("planing")
+        print("planing: ", config)
         # pass
-        mr.run_on_meta(config, generate_only=True)
-        mr.run_on_meta(config)
-        break
+        mr.run_on_meta(config, 
+            run_job_kwargs={"conda_module": "prompt"}, 
+            plan_job_kwargs={"script_name": f"augmenter-{config['a']}+{config['b']}"}, 
+            generate_only=True)
+        #mr.run_on_meta(config, generate_only=True)
+        #mr.run_on_meta(config)
 
     # mr.dry_run(config)

--- a/metarunner.py
+++ b/metarunner.py
@@ -53,9 +53,17 @@ class Metarunner():
         # output = proc_out.stdout.decode("utf-8")
         # print(" ".join(args))
 
-    def run_on_meta(self, config, in_sequence=1, generate_only=False, last_run_ckpts=None, depend_on=None):
+    def run_on_meta(
+        self, config, 
+        run_job_kwargs = None, 
+        plan_job_kwargs = None, 
+        in_sequence=1, 
+        generate_only=False, 
+        last_run_ckpts=None, 
+        depend_on=None):
 
         previous_id = 0 if depend_on is None else depend_on
+        run_job_kwargs, plan_job_kwargs = run_job_kwargs or {}, plan_job_kwargs or {}
 
         os.makedirs(self.script_paths, exist_ok=True)
         ids = []
@@ -91,7 +99,7 @@ class Metarunner():
                 config["metarunner_seq_num"] = in_sequence
 
             # create in-singularity script
-            runinng_script = self.generate_run_job_template(config)
+            runinng_script = self.generate_run_job_template(config, **run_job_kwargs)
             with open(job_script, "w", encoding="utf-8") as in_singularity_fd:
                 in_singularity_fd.write(runinng_script)
                 if generate_only:
@@ -101,7 +109,7 @@ class Metarunner():
 
             # create main script
             with open(plan_script, "w", encoding="utf-8") as main_script_fd:
-                planning_script = self.generate_plan_job_template(job_script)
+                planning_script = self.generate_plan_job_template(job_script, **plan_job_kwargs)
                 main_script_fd.write(planning_script)
                 if generate_only:
                     print("main qsub script was generated")
@@ -148,3 +156,5 @@ class Metarunner():
             # m = JOB_ID_RE.match(output)
             previous_id = output.strip()  # int(m.group())
         print("-------------------\n" + "".join(ids))
+
+    __call__ = run_on_meta


### PR DESCRIPTION
Generátory plan resp. run templatů můžou mít další argumenty kromě job_script resp. named_args - tyto argumenty se předají jako slovník metodě run_on_meta, která je doplní.

Toto je vhodné, když spouštění Metarunneru a volání metody grid_config neleží ve stejném souboru jako funkce pro generování templatů bash skriptů (generátory nemusí mít přístup k proměnným z druhého skriptu, i když potřebují znát jejich hodnotu - touto úpravou je možné hodnotu poslat přes argument).

Příklad:

soubor templates.py:
```py
    PROJECT_DIR = "/storage/plzen1/home/scrub/prompt"
    MAIN_SCRIPT = "src/example.py"

    def generate_plan_job(job_script, script_name="augmenter"):
        return f"""#!/bin/bash
                #PBS -q gpu@cerit-pbs.cerit-sc.cz
                #P-BS -q gpu@meta-pbs.metacentrum.cz
                #PBS -l walltime=0:59:0
                #PBS -l select=1:ncpus=1:ngpus=1:mem=40000mb:scratch_local=40000mb:cl_zia=True
                #P-BS -l select=1:ncpus=1:ngpus=1:mem=40000mb:scratch_local=40000mb:cl_galdor=True
                #PBS -N {script_name}

                /bin/bash {job_script}
                """


    def generate_run_job(named_args, conda_module="prompt"):
        named_params = " ".join(f"--{k} {v}" for k, v in named_args.items())
        return f"""#!/bin/bash
                module add conda-modules

                HOME=/storage/plzen1/scrub/prompt
                conda activate {conda_module}

                export TMPDIR=$SCRATCH

                cd {PROJECT_DIR}
                export PYTHONPATH=$(pwd)
                python {MAIN_SCRIPT} {named_params}
                """
```

soubor run_meta.py:
```py
    from templates import generate_run_job, generate_plan_job

    mr = Metarunner(generate_plan_job, generate_run_job,
                    f"{PROJECT_DIR}/metarunner",
                    project_dir=PROJECT_DIR, python_script=MAIN_SCRIPT
                    )
    map_hp_vals = {
        "a": [ 5, 1 ],
        "b": [ 7, 2]}

    confs = Metarunner.grid_config(map_hp_vals)
    for i, config in enumerate(confs):
        mr.run_on_meta(config, 
            run_job_kwargs={"conda_module": "prompt"}, 
            plan_job_kwargs={"script_name": f"augmenter-{i}"}, 
            generate_only=True)
```

- Skript run_meta.py generuje úlohy augmenter-0, augmenter-1, augmenter-2 a augmenter-3. Jelikož však funkce na generování bash skriptů leží v jiném souboru, nemá přístup k proměnné `i` cyklu for a je tedy potřeba její hodnotu předat argumentem.